### PR TITLE
fix: Handle NEXT_REDIRECT errors properly in server actions

### DIFF
--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -17,7 +17,7 @@ export async function trackEvent(eventName: string, userId: string) {
 
 export async function advanceStep(stepIndex: number, distinctId: string) {
   'use server';
-  
+
   after(async () => {
     try {
       // Capture server-side acknowledgment
@@ -39,11 +39,12 @@ export async function advanceStep(stepIndex: number, distinctId: string) {
 
       await shutdownPostHog();
     } catch (error) {
-      console.error('Error in advanceStep:', error);
+      console.error('Error in advanceStep after hook:', error);
     }
   });
 
   // Navigate to next step or finish
+  // Note: redirect() throws internally, but this is expected behavior in Next.js
   if (stepIndex < 7) {
     redirect(`/steps/${stepIndex + 1}`);
   } else {

--- a/src/app/steps/[index]/page.tsx
+++ b/src/app/steps/[index]/page.tsx
@@ -66,18 +66,10 @@ export default function StepPage() {
   }, [stepIndex]);
 
   const handleNext = async () => {
-    try {
-      const distinctId = getDistinctId();
-      await advanceStep(stepIndex, distinctId);
-    } catch (error) {
-      // Next.js redirects throw a special error that should be re-thrown
-      // to allow the redirect to proceed normally
-      if (error && typeof error === 'object' && 'digest' in error) {
-        throw error;
-      }
-      // Log other errors but don't block the redirect
-      console.error('Error in handleNext:', error);
-    }
+    const distinctId = getDistinctId();
+    // No need to wrap in try-catch since redirect throws intentionally
+    // The redirect error will be handled by Next.js internally
+    await advanceStep(stepIndex, distinctId);
   };
 
   if (!isInitialized || stepIndex < 1 || stepIndex > 7) {


### PR DESCRIPTION
Fixes #1

## Summary

This PR fixes the NEXT_REDIRECT UnhandledRejection error by removing improper error handling around Next.js's `redirect()` function.

## Changes

- Remove try-catch wrapper around redirect() calls to let Next.js handle them properly
- Update error message for clarity in after() hook
- Remove unnecessary error handling that was causing unhandled rejections

The redirect() function in Next.js throws internally as part of its control flow, and these errors should not be caught. This was causing unhandled promise rejections.

Generated with [Claude Code](https://claude.ai/code)